### PR TITLE
Disable KernelPM to enable HWP Correctly

### DIFF
--- a/Clover EFI/EFI/CLOVER/config.plist
+++ b/Clover EFI/EFI/CLOVER/config.plist
@@ -386,7 +386,7 @@
 		<key>KernelLapic</key>
 		<true/>
 		<key>KernelPm</key>
-		<true/>
+		<false/>
 		<key>KernelToPatch</key>
 		<array>
 			<dict>


### PR DESCRIPTION
 * HWP is enabled with MSR Locked (Thanks to Pike R. Alpha), but C-States still not enabled.
 * This commit disable KernelPM to enable C-States correctly.

Test: Checked in Hackintool.

Signed-off-by: Yang Jeong Hun <onyxclover9931@gmail.com>